### PR TITLE
fix: update graceful-fs for Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Tomas Pollak <tomas@forkhq.com>",
   "license": "WTFPL",
   "dependencies": {
-    "graceful-fs": "^3.0.3",
+    "graceful-fs": "^4.2.4",
     "uid-number": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
`graceful-fs` @3.0 is incompatible with Node.js 12

```
ReferenceError: primordials is not defined
    at fs.js:27:26
    at req_ (/home/okdistribute/dev/mapeo-desktop/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/okdistribute/dev/mapeo-desktop/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/okdistribute/dev/mapeo-desktop/node_modules/chela/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:967:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1004:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module._load (electron/js2c/asar.js:769:28)
    at Module.require (internal/modules/cjs/loader.js:852:19)
```